### PR TITLE
TTL business validator

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     repositories {
         mavenLocal()
         mavenCentral()
-        maven { url "http://repo.spring.io/plugins-release" }
+        maven { url "https://repo.spring.io/plugins-release" }
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {

--- a/src/main/java/com/icthh/xm/tmf/ms/communication/config/KafkaChannelFactory.java
+++ b/src/main/java/com/icthh/xm/tmf/ms/communication/config/KafkaChannelFactory.java
@@ -127,13 +127,13 @@ public class KafkaChannelFactory {
 
         try {
             String payloadString = (String) message.getPayload();
-            log.info("start processign message, base64 body = {}, headers = {}", payloadString, getHeaders(message));
+            log.info("start processing message, base64 body = {}, headers = {}", payloadString, getHeaders(message));
             payloadString = unwrap(payloadString, "\"");
-            log.info("start processign message, json body = {}", payloadString);
+            log.info("start processing message, json body = {}", payloadString);
             CommunicationMessage communicationMessage = mapToCommunicationMessage(payloadString);
             addReceivedByChannelCharacteristic(communicationMessage, message);
             messagingHandler.receiveMessage(communicationMessage);
-            log.info("stop processign message, time = {}", stopWatch.getTime());
+            log.info("stop processing message, time = {}", stopWatch.getTime());
         } catch (Exception e) {
             log.error("Error process event", e);
         }

--- a/src/main/java/com/icthh/xm/tmf/ms/communication/messaging/MessagingHandler.java
+++ b/src/main/java/com/icthh/xm/tmf/ms/communication/messaging/MessagingHandler.java
@@ -54,7 +54,7 @@ public class MessagingHandler {
                    wrapper.getDeliveryReport());
                 String queueName = messaging.getSentQueueName();
                 sendMessage(success(messageId, message), queueName);
-                log.info("Message success sended to {}", queueName);
+                log.info("Message success sent to {}", queueName);
             } catch (NegativeResponseException e) {
                 log.error(ERROR_PROCESS_COMMUNICATION_MESSAGE, e);
                 failMessage(message, "error.system.sending.smpp." + e.getCommandStatus(), e.getMessage());
@@ -81,7 +81,7 @@ public class MessagingHandler {
         Messaging messaging = applicationProperties.getMessaging();
         String failedQueueName = messaging.getSendFailedQueueName();
         sendMessage(failed(communicationMessage, code, message), failedQueueName);
-        log.warn("Message about error sended to {}", failedQueueName);
+        log.warn("Message about error sent to {}", failedQueueName);
     }
 
 }

--- a/src/main/java/com/icthh/xm/tmf/ms/communication/rules/ttl/TTLRule.java
+++ b/src/main/java/com/icthh/xm/tmf/ms/communication/rules/ttl/TTLRule.java
@@ -45,6 +45,7 @@ public class TTLRule implements BusinessRule {
                                 break;
                             case NONE:
                                 // Nothing - filtered before
+                                break;
                             default:
                                 log.error("The behaviour for the following action value is not implemented: {}", config.getAction());
                         }

--- a/src/main/java/com/icthh/xm/tmf/ms/communication/rules/ttl/TTLRule.java
+++ b/src/main/java/com/icthh/xm/tmf/ms/communication/rules/ttl/TTLRule.java
@@ -3,11 +3,13 @@ package com.icthh.xm.tmf.ms.communication.rules.ttl;
 import com.icthh.xm.tmf.ms.communication.rules.BusinessRule;
 import com.icthh.xm.tmf.ms.communication.rules.RuleResponse;
 import com.icthh.xm.tmf.ms.communication.web.api.model.CommunicationMessage;
+import com.icthh.xm.tmf.ms.communication.web.api.model.CommunicationRequestCharacteristic;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Date;
+import java.util.Objects;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -42,10 +44,11 @@ public class TTLRule implements BusinessRule {
     private void applyRule(CommunicationMessage message, Duration ttl, RuleResponse ruleResponse) {
         message.getCharacteristic().stream()
             .filter((characteristic) -> MESSAGE_RECEIVED_BY_CHANNEL_TIMESTAMP.equals(characteristic.getName()))
-            .peek((characteristic) -> log.debug("The following bornTime is found: {}", characteristic.getValue()))
+            .map(CommunicationRequestCharacteristic::getValue)
+            .peek((bornTimestamp) -> log.debug("The following bornTime is found: {}", bornTimestamp))
             .findAny()
-            .filter((characteristic) -> characteristic.getValue() != null)
-            .map((characteristic) -> new Date(Long.valueOf(characteristic.getValue())).toInstant())
+            .filter(Objects::nonNull)
+            .map((bornTimestamp) -> new Date(Long.valueOf(bornTimestamp)).toInstant())
             .filter((bornTime) -> Instant.now().minus(ttl).isAfter(bornTime))
             .ifPresent((bornTime) -> doAction(bornTime, ruleResponse));
     }

--- a/src/main/java/com/icthh/xm/tmf/ms/communication/rules/ttl/TTLRule.java
+++ b/src/main/java/com/icthh/xm/tmf/ms/communication/rules/ttl/TTLRule.java
@@ -43,14 +43,15 @@ public class TTLRule implements BusinessRule {
 
     private void applyRule(CommunicationMessage message, Duration ttl, RuleResponse ruleResponse) {
         message.getCharacteristic().stream()
-            .filter((characteristic) -> MESSAGE_RECEIVED_BY_CHANNEL_TIMESTAMP.equals(characteristic.getName()))
+            .filter(characteristic -> MESSAGE_RECEIVED_BY_CHANNEL_TIMESTAMP.equals(characteristic.getName()))
             .map(CommunicationRequestCharacteristic::getValue)
-            .peek((bornTimestamp) -> log.debug("The following bornTime is found: {}", bornTimestamp))
+            .peek(bornTimestamp -> log.debug("The following bornTime is found: {}", bornTimestamp))
             .findAny()
             .filter(Objects::nonNull)
-            .map((bornTimestamp) -> new Date(Long.valueOf(bornTimestamp)).toInstant())
-            .filter((bornTime) -> Instant.now().minus(ttl).isAfter(bornTime))
-            .ifPresent((bornTime) -> doAction(bornTime, ruleResponse));
+            .map(Long::valueOf)
+            .map(bornTimestamp -> new Date(bornTimestamp).toInstant())
+            .filter(bornTime -> Instant.now().minus(ttl).isAfter(bornTime))
+            .ifPresent(bornTime -> doAction(bornTime, ruleResponse));
     }
 
     private void doAction(Instant bornTime, RuleResponse ruleResponse) {

--- a/src/main/java/com/icthh/xm/tmf/ms/communication/rules/ttl/TTLRule.java
+++ b/src/main/java/com/icthh/xm/tmf/ms/communication/rules/ttl/TTLRule.java
@@ -1,0 +1,61 @@
+package com.icthh.xm.tmf.ms.communication.rules.ttl;
+
+import com.icthh.xm.tmf.ms.communication.rules.BusinessRule;
+import com.icthh.xm.tmf.ms.communication.rules.RuleResponse;
+import com.icthh.xm.tmf.ms.communication.web.api.model.CommunicationMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+
+@Slf4j
+@RequiredArgsConstructor
+public class TTLRule implements BusinessRule {
+
+    public static final String TTL_EXCEED_MESSAGE_CODE = "error.business.sending.ttlExceeded";
+    public static final String MESSAGE_RECEIVED_BY_CHANNEL_TIMESTAMP = "MESSAGE_RECEIVED_BY_CHANNEL_TIMESTAMP";
+    private static final String TTL_RULE = "TTLRule";
+
+    private final TTLRuleConfigService configService;
+
+    @Override
+    public RuleResponse validate(CommunicationMessage message) {
+        RuleResponse ruleResponse = new RuleResponse();
+        ruleResponse.setRuleType(TTL_RULE);
+        ruleResponse.setResponseCode(TTL_EXCEED_MESSAGE_CODE);
+        ruleResponse.setSuccess(true);
+        TTLRuleConfig config = configService.getTtlRuleConfig();
+        if (config != null && message.getCharacteristic() != null) {
+            config.getTTL().ifPresent((ttl) ->
+                message.getCharacteristic().stream()
+                    .filter((characteristic) -> MESSAGE_RECEIVED_BY_CHANNEL_TIMESTAMP.equals(characteristic.getName()))
+                    .findFirst()
+                    .filter((characteristic) -> characteristic.getValue() != null)
+                    .map((characteristic) -> new Date(Long.valueOf(characteristic.getValue())).toInstant())
+                    .filter((bornTime) -> Instant.now().minus(ttl).isAfter(bornTime))
+                    .ifPresent((bornTime) -> ruleResponse.setSuccess(false))
+            );
+            if (log.isDebugEnabled()) {
+                // do it only for debug mode
+                if (config.isActive()) {
+                    Duration ttl = config.getTTL().get();
+                    message.getCharacteristic().stream()
+                        .filter((characteristic) -> MESSAGE_RECEIVED_BY_CHANNEL_TIMESTAMP.equals(characteristic.getName()))
+                        .peek((characteristic) -> log.debug("The following bornTime is found: {}", characteristic.getValue()))
+                        .findFirst()
+                        .filter((characteristic) -> characteristic.getValue() != null)
+                        .map((characteristic) -> new Date(Long.valueOf(characteristic.getValue())).toInstant())
+                        .filter((bornTime) -> Instant.now().minus(ttl).isAfter(bornTime))
+                        .ifPresent((bornTime) -> log.debug("The following bornTime is rejected: {}", bornTime));
+                } else {
+                    log.debug("TTLRule is turned off");
+                }
+            }
+        } else {
+            log.debug("TTLRule is not configured");
+        }
+        return ruleResponse;
+    }
+}

--- a/src/main/java/com/icthh/xm/tmf/ms/communication/rules/ttl/TTLRuleConfig.java
+++ b/src/main/java/com/icthh/xm/tmf/ms/communication/rules/ttl/TTLRuleConfig.java
@@ -1,0 +1,33 @@
+package com.icthh.xm.tmf.ms.communication.rules.ttl;
+
+import lombok.Value;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+
+@Value
+public class TTLRuleConfig {
+
+    private TTLConfiguration ttlRule;
+
+    @Value
+    public static class TTLConfiguration {
+        private Long value;
+        private String chronoUnit;
+    }
+    public boolean isActive(){
+        return ttlRule != null
+            && ttlRule.value != null
+            && ttlRule.value > 0;
+    }
+
+    public Optional<Duration> getTTL(){
+        if (isActive()){
+            Duration ttl = Duration.of(ttlRule.value, ChronoUnit.valueOf(ttlRule.chronoUnit));
+            return Optional.of(ttl);
+        }else{
+            return Optional.empty();
+        }
+    }
+}

--- a/src/main/java/com/icthh/xm/tmf/ms/communication/rules/ttl/TTLRuleConfig.java
+++ b/src/main/java/com/icthh/xm/tmf/ms/communication/rules/ttl/TTLRuleConfig.java
@@ -1,7 +1,7 @@
 package com.icthh.xm.tmf.ms.communication.rules.ttl;
 
-import static com.icthh.xm.tmf.ms.communication.rules.ttl.TTLRuleConfig.Action.*;
-
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import lombok.Value;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
@@ -19,8 +19,12 @@ public class TTLRuleConfig {
         private Action action;
     }
 
+    @Getter
+    @RequiredArgsConstructor
     public enum Action {
-        NONE, REJECT, WARNING;
+        NONE(false), REJECT(true), WARNING(true);
+
+        private final boolean active;
 
         public static Action getDefaultValue(){
             return NONE;
@@ -28,9 +32,7 @@ public class TTLRuleConfig {
     }
 
     public boolean isActive(){
-        return ttlRule != null
-            && ttlRule.action != null
-            && ttlRule.action != NONE;
+        return getAction().isActive();
     }
 
     public Optional<Duration> getTTL(){
@@ -43,6 +45,6 @@ public class TTLRuleConfig {
     }
 
     public Action getAction(){
-        return (ttlRule == null || ttlRule.action == null) ? NONE : ttlRule.action;
+        return (ttlRule == null || ttlRule.action == null) ? Action.getDefaultValue() : ttlRule.action;
     }
 }

--- a/src/main/java/com/icthh/xm/tmf/ms/communication/rules/ttl/TTLRuleConfig.java
+++ b/src/main/java/com/icthh/xm/tmf/ms/communication/rules/ttl/TTLRuleConfig.java
@@ -1,7 +1,8 @@
 package com.icthh.xm.tmf.ms.communication.rules.ttl;
 
-import lombok.Value;
+import static com.icthh.xm.tmf.ms.communication.rules.ttl.TTLRuleConfig.Action.*;
 
+import lombok.Value;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.Optional;
@@ -15,11 +16,21 @@ public class TTLRuleConfig {
     public static class TTLConfiguration {
         private Long value;
         private String chronoUnit;
+        private Action action;
     }
+
+    public enum Action {
+        NONE, REJECT, WARNING;
+
+        public static Action getDefaultValue(){
+            return NONE;
+        }
+    }
+
     public boolean isActive(){
         return ttlRule != null
-            && ttlRule.value != null
-            && ttlRule.value > 0;
+            && ttlRule.action != null
+            && ttlRule.action != NONE;
     }
 
     public Optional<Duration> getTTL(){
@@ -29,5 +40,9 @@ public class TTLRuleConfig {
         }else{
             return Optional.empty();
         }
+    }
+
+    public Action getAction(){
+        return (ttlRule == null || ttlRule.action == null) ? NONE : ttlRule.action;
     }
 }

--- a/src/main/java/com/icthh/xm/tmf/ms/communication/rules/ttl/TTLRuleConfigService.java
+++ b/src/main/java/com/icthh/xm/tmf/ms/communication/rules/ttl/TTLRuleConfigService.java
@@ -19,7 +19,7 @@ import org.springframework.stereotype.Component;
 @Getter
 public class TTLRuleConfigService extends TenantConfigService {
 
-    TTLRuleConfig ttlRuleConfig;
+    private TTLRuleConfig ttlRuleConfig;
 
     public TTLRuleConfigService(XmConfigProperties xmConfigProperties, TenantContextHolder tenantContextHolder) {
         super(xmConfigProperties, tenantContextHolder);

--- a/src/main/java/com/icthh/xm/tmf/ms/communication/rules/ttl/TTLRuleConfigService.java
+++ b/src/main/java/com/icthh/xm/tmf/ms/communication/rules/ttl/TTLRuleConfigService.java
@@ -35,6 +35,9 @@ public class TTLRuleConfigService extends TenantConfigService {
         objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
         ttlRuleConfig = objectMapper.readValue(config, TTLRuleConfig.class);
+        if (ttlRuleConfig != null && ttlRuleConfig.getAction() == null){
+            log.warn("TTLRule action is not set, {} value will be used as default!", TTLRuleConfig.Action.getDefaultValue());
+        }
         log.debug("Update ttlRuleConfig: {}", ttlRuleConfig);
     }
 

--- a/src/main/java/com/icthh/xm/tmf/ms/communication/rules/ttl/TTLRuleConfigService.java
+++ b/src/main/java/com/icthh/xm/tmf/ms/communication/rules/ttl/TTLRuleConfigService.java
@@ -1,0 +1,41 @@
+package com.icthh.xm.tmf.ms.communication.rules.ttl;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.icthh.xm.commons.config.client.config.XmConfigProperties;
+import com.icthh.xm.commons.config.client.service.TenantConfigService;
+import com.icthh.xm.commons.tenant.TenantContextHolder;
+import lombok.Getter;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@Primary
+@Getter
+public class TTLRuleConfigService extends TenantConfigService {
+
+    TTLRuleConfig ttlRuleConfig;
+
+    public TTLRuleConfigService(XmConfigProperties xmConfigProperties, TenantContextHolder tenantContextHolder) {
+        super(xmConfigProperties, tenantContextHolder);
+    }
+
+    @SneakyThrows
+    @Override
+    public void onRefresh(String updatedKey, String config) {
+        super.onRefresh(updatedKey, config);
+
+        ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory());
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+        ttlRuleConfig = objectMapper.readValue(config, TTLRuleConfig.class);
+        log.debug("Update ttlRuleConfig: {}", ttlRuleConfig);
+    }
+
+}

--- a/src/test/java/com/icthh/xm/tmf/ms/communication/config/TenantConfigMockConfiguration.java
+++ b/src/test/java/com/icthh/xm/tmf/ms/communication/config/TenantConfigMockConfiguration.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 import com.icthh.xm.commons.config.client.repository.TenantConfigRepository;
 import com.icthh.xm.commons.config.client.repository.TenantListRepository;
 import com.icthh.xm.tmf.ms.communication.rules.businesstime.BusinessTimeConfigService;
+import com.icthh.xm.tmf.ms.communication.rules.ttl.TTLRuleConfigService;
 import java.util.Collections;
 import java.util.Set;
 import org.springframework.context.annotation.Bean;
@@ -41,5 +42,10 @@ public class TenantConfigMockConfiguration {
     @Bean
     public BusinessTimeConfigService businessTimeConfigService() {
         return mock(BusinessTimeConfigService.class);
+    }
+
+    @Bean("TTLRuleConfigService")
+    public TTLRuleConfigService ttlRuleConfigService() {
+        return mock(TTLRuleConfigService.class);
     }
 }

--- a/src/test/java/com/icthh/xm/tmf/ms/communication/rules/TTLRuleTest.java
+++ b/src/test/java/com/icthh/xm/tmf/ms/communication/rules/TTLRuleTest.java
@@ -90,12 +90,12 @@ public class TTLRuleTest {
     }
 
     @Test
-    public void inDefaultActionConfigTest() throws Throwable {
+    public void defaultActionConfigTest() throws Throwable {
         TTLRuleConfig ttlRuleConfig = loadDefaultActionConfig();
 
         assertEquals(new Long(1), ttlRuleConfig.getTtlRule().getValue());
         assertEquals(ChronoUnit.MILLIS.name(), ttlRuleConfig.getTtlRule().getChronoUnit());
-        assertEquals(TTLRuleConfig.Action.NONE, ttlRuleConfig.getAction());
+        assertEquals(TTLRuleConfig.Action.getDefaultValue(), ttlRuleConfig.getAction());
         assertFalse(ttlRuleConfig.isActive());
     }
 

--- a/src/test/java/com/icthh/xm/tmf/ms/communication/rules/TTLRuleTest.java
+++ b/src/test/java/com/icthh/xm/tmf/ms/communication/rules/TTLRuleTest.java
@@ -90,6 +90,16 @@ public class TTLRuleTest {
     }
 
     @Test
+    public void warningConfigTest() throws Throwable {
+        TTLRuleConfig ttlRuleConfig = loadWarningConfig();
+
+        assertEquals(new Long(1), ttlRuleConfig.getTtlRule().getValue());
+        assertEquals(ChronoUnit.MILLIS.name(), ttlRuleConfig.getTtlRule().getChronoUnit());
+        assertEquals(TTLRuleConfig.Action.WARNING, ttlRuleConfig.getAction());
+        assertTrue(ttlRuleConfig.isActive());
+    }
+
+    @Test
     public void defaultActionConfigTest() throws Throwable {
         TTLRuleConfig ttlRuleConfig = loadDefaultActionConfig();
 
@@ -151,6 +161,20 @@ public class TTLRuleTest {
         ));
     }
 
+    /**
+     * Test that outdated message is not rejected
+     */
+    @Test
+    public void validateWarningTest() throws Throwable {
+        loadWarningConfig();
+
+        successCheck(message().addCharacteristicItem(
+            new CommunicationRequestCharacteristic()
+                .name(MESSAGE_RECEIVED_BY_CHANNEL_TIMESTAMP)
+                .value(String.valueOf(Instant.now().toEpochMilli()))
+        ));
+    }
+
     @Test
     public void validateMessageOutdatedBornTimeTest() throws Throwable {
         loadOneMillisecondConfig();
@@ -182,6 +206,10 @@ public class TTLRuleTest {
 
     private TTLRuleConfig loadInactiveConfig() throws IOException {
         return refreshConfig("ttlInaciveConfig.yml");
+    }
+
+    private TTLRuleConfig loadWarningConfig() throws IOException {
+        return refreshConfig("ttlWarningConfig.yml");
     }
 
     private TTLRuleConfig loadDefaultActionConfig() throws IOException {

--- a/src/test/java/com/icthh/xm/tmf/ms/communication/rules/TTLRuleTest.java
+++ b/src/test/java/com/icthh/xm/tmf/ms/communication/rules/TTLRuleTest.java
@@ -75,6 +75,7 @@ public class TTLRuleTest {
         assertEquals(new Long(30), ttlRuleConfig.getTtlRule().getValue());
         assertEquals(ChronoUnit.MINUTES.name(), ttlRuleConfig.getTtlRule().getChronoUnit());
         assertEquals(Duration.ofMinutes(30L), ttlRuleConfig.getTTL().get());
+        assertEquals(TTLRuleConfig.Action.REJECT, ttlRuleConfig.getAction());
         assertTrue(ttlRuleConfig.isActive());
     }
 
@@ -82,8 +83,19 @@ public class TTLRuleTest {
     public void inActiveConfigTest() throws Throwable {
         TTLRuleConfig ttlRuleConfig = loadInactiveConfig();
 
-        assertEquals(new Long(-1), ttlRuleConfig.getTtlRule().getValue());
-        assertNull(ttlRuleConfig.getTtlRule().getChronoUnit());
+        assertEquals(new Long(1), ttlRuleConfig.getTtlRule().getValue());
+        assertEquals(ChronoUnit.MILLIS.name(), ttlRuleConfig.getTtlRule().getChronoUnit());
+        assertEquals(TTLRuleConfig.Action.NONE, ttlRuleConfig.getAction());
+        assertFalse(ttlRuleConfig.isActive());
+    }
+
+    @Test
+    public void inDefaultActionConfigTest() throws Throwable {
+        TTLRuleConfig ttlRuleConfig = loadDefaultActionConfig();
+
+        assertEquals(new Long(1), ttlRuleConfig.getTtlRule().getValue());
+        assertEquals(ChronoUnit.MILLIS.name(), ttlRuleConfig.getTtlRule().getChronoUnit());
+        assertEquals(TTLRuleConfig.Action.NONE, ttlRuleConfig.getAction());
         assertFalse(ttlRuleConfig.isActive());
     }
 
@@ -109,6 +121,17 @@ public class TTLRuleTest {
     @Test
     public void validateInactiveConfigTest() throws Throwable {
         loadInactiveConfig();
+
+        successCheck(message().addCharacteristicItem(
+            new CommunicationRequestCharacteristic()
+                .name(MESSAGE_RECEIVED_BY_CHANNEL_TIMESTAMP)
+                .value(String.valueOf(Instant.now().toEpochMilli()))
+        ));
+    }
+
+    @Test
+    public void validateDefaultActionConfigTest() throws Throwable {
+        loadDefaultActionConfig();
 
         successCheck(message().addCharacteristicItem(
             new CommunicationRequestCharacteristic()
@@ -159,6 +182,10 @@ public class TTLRuleTest {
 
     private TTLRuleConfig loadInactiveConfig() throws IOException {
         return refreshConfig("ttlInaciveConfig.yml");
+    }
+
+    private TTLRuleConfig loadDefaultActionConfig() throws IOException {
+        return refreshConfig("ttlDefaultActionConfig.yml");
     }
 
     private TTLRuleConfig loadNoConfig() throws IOException {

--- a/src/test/java/com/icthh/xm/tmf/ms/communication/rules/TTLRuleTest.java
+++ b/src/test/java/com/icthh/xm/tmf/ms/communication/rules/TTLRuleTest.java
@@ -80,7 +80,7 @@ public class TTLRuleTest {
     }
 
     @Test
-    public void inActiveConfigTest() throws Throwable {
+    public void inactiveConfigTest() throws Throwable {
         TTLRuleConfig ttlRuleConfig = loadInactiveConfig();
 
         assertEquals(new Long(1), ttlRuleConfig.getTtlRule().getValue());

--- a/src/test/java/com/icthh/xm/tmf/ms/communication/rules/TTLRuleTest.java
+++ b/src/test/java/com/icthh/xm/tmf/ms/communication/rules/TTLRuleTest.java
@@ -1,0 +1,200 @@
+package com.icthh.xm.tmf.ms.communication.rules;
+
+import static com.icthh.xm.tmf.ms.communication.domain.MessageResponse.Status.FAILED;
+import static com.icthh.xm.tmf.ms.communication.domain.MessageResponse.Status.SUCCESS;
+import static com.icthh.xm.tmf.ms.communication.messaging.MessagingTest.*;
+import static com.icthh.xm.tmf.ms.communication.rules.ttl.TTLRule.MESSAGE_RECEIVED_BY_CHANNEL_TIMESTAMP;
+import static com.icthh.xm.tmf.ms.communication.rules.ttl.TTLRule.TTL_EXCEED_MESSAGE_CODE;
+import static java.nio.charset.Charset.defaultCharset;
+import static java.util.Collections.singletonList;
+import static java.util.Objects.requireNonNull;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.icthh.xm.commons.config.client.config.XmConfigProperties;
+import com.icthh.xm.commons.tenant.TenantContextHolder;
+import com.icthh.xm.tmf.ms.communication.domain.MessageResponse;
+import com.icthh.xm.tmf.ms.communication.messaging.MessagingHandler;
+import com.icthh.xm.tmf.ms.communication.rules.ttl.TTLRule;
+import com.icthh.xm.tmf.ms.communication.rules.ttl.TTLRuleConfig;
+import com.icthh.xm.tmf.ms.communication.rules.ttl.TTLRuleConfigService;
+import com.icthh.xm.tmf.ms.communication.service.SmppService;
+import com.icthh.xm.tmf.ms.communication.web.api.model.CommunicationMessage;
+import com.icthh.xm.tmf.ms.communication.web.api.model.CommunicationRequestCharacteristic;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.IOUtils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import java.io.IOException;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+@Slf4j
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = {TTLRuleConfigService.class})
+public class TTLRuleTest {
+
+    private static final String UPDATED_KEY = "/config/tenants/xm/tenant-config.yml";
+
+    @Mock
+    private KafkaTemplate<String, Object> kafkaTemplate;
+
+    @Mock
+    private SmppService smppService;
+
+    @Mock
+    private Clock clock;
+
+    @MockBean
+    private XmConfigProperties xmConfigProperties;
+
+    @MockBean
+    private TenantContextHolder tenantContextHolder;
+
+    @Autowired
+    private TTLRuleConfigService ttlRuleConfigService;
+
+    private MessagingHandler messagingHandler;
+
+    @Test
+    public void activeConfigTest() throws Throwable {
+        TTLRuleConfig ttlRuleConfig = load30minConfig();
+
+        assertEquals(new Long(30), ttlRuleConfig.getTtlRule().getValue());
+        assertEquals(ChronoUnit.MINUTES.name(), ttlRuleConfig.getTtlRule().getChronoUnit());
+        assertEquals(Duration.ofMinutes(30L), ttlRuleConfig.getTTL().get());
+        assertTrue(ttlRuleConfig.isActive());
+    }
+
+    @Test
+    public void inActiveConfigTest() throws Throwable {
+        TTLRuleConfig ttlRuleConfig = loadInactiveConfig();
+
+        assertEquals(new Long(-1), ttlRuleConfig.getTtlRule().getValue());
+        assertNull(ttlRuleConfig.getTtlRule().getChronoUnit());
+        assertFalse(ttlRuleConfig.isActive());
+    }
+
+    @Test
+    public void noConfigTest() throws Throwable {
+        TTLRuleConfig ttlRuleConfig = loadNoConfig();
+
+        assertNull(ttlRuleConfig.getTtlRule());
+        assertFalse(ttlRuleConfig.isActive());
+    }
+
+    @Test
+    public void validateMessageSuccessBornTimeTest() throws Throwable {
+        load30minConfig();
+
+        successCheck(message().addCharacteristicItem(
+            new CommunicationRequestCharacteristic()
+                .name(MESSAGE_RECEIVED_BY_CHANNEL_TIMESTAMP)
+                .value(String.valueOf(Instant.now().toEpochMilli()))
+        ));
+    }
+
+    @Test
+    public void validateInactiveConfigTest() throws Throwable {
+        loadInactiveConfig();
+
+        successCheck(message().addCharacteristicItem(
+            new CommunicationRequestCharacteristic()
+                .name(MESSAGE_RECEIVED_BY_CHANNEL_TIMESTAMP)
+                .value(String.valueOf(Instant.now().toEpochMilli()))
+        ));
+    }
+
+    @Test
+    public void validateNoConfigTest() throws Throwable {
+        loadNoConfig();
+
+        successCheck(message().addCharacteristicItem(
+            new CommunicationRequestCharacteristic()
+                .name(MESSAGE_RECEIVED_BY_CHANNEL_TIMESTAMP)
+                .value(String.valueOf(Instant.now().toEpochMilli()))
+        ));
+    }
+
+    @Test
+    public void validateMessageOutdatedBornTimeTest() throws Throwable {
+        loadOneMillisecondConfig();
+
+        failureCheck(message().addCharacteristicItem(
+            new CommunicationRequestCharacteristic()
+                .name(MESSAGE_RECEIVED_BY_CHANNEL_TIMESTAMP)
+                .value(String.valueOf(Instant.now().toEpochMilli()))
+        ));
+    }
+
+    private TTLRuleConfig refreshConfig(String configFile) throws IOException {
+        ttlRuleConfigService.onRefresh(UPDATED_KEY, IOUtils.toString(
+            requireNonNull(getClass().getClassLoader().getResourceAsStream(configFile)),
+            defaultCharset()));
+        TTLRule ttlRule = new TTLRule(ttlRuleConfigService);
+        BusinessRuleValidator businessRuleValidator = new BusinessRuleValidator(singletonList(ttlRule));
+        messagingHandler = new MessagingHandler(kafkaTemplate,
+            smppService,
+            createApplicationProperties(),
+            businessRuleValidator);
+
+        return ttlRuleConfigService.getTtlRuleConfig();
+    }
+
+    private TTLRuleConfig load30minConfig() throws IOException {
+        return refreshConfig("ttl30minConfig.yml");
+    }
+
+    private TTLRuleConfig loadInactiveConfig() throws IOException {
+        return refreshConfig("ttlInaciveConfig.yml");
+    }
+
+    private TTLRuleConfig loadNoConfig() throws IOException {
+        return refreshConfig("ttlNoConfig.yml");
+    }
+
+    private TTLRuleConfig loadOneMillisecondConfig() throws IOException {
+        return refreshConfig("ttlOneMillisecondConfig.yml");
+    }
+
+    private void successCheck(CommunicationMessage message) {
+        messagingHandler.receiveMessage(message);
+        MessageResponse messageResponse = new MessageResponse(SUCCESS, message);
+        ArgumentCaptor<MessageResponse> argumentCaptor = ArgumentCaptor.forClass(MessageResponse.class);
+        verify(kafkaTemplate).send(eq(SUCCESS_SENT), argumentCaptor.capture());
+        MessageResponse payload = argumentCaptor.getValue();
+        payload.setId(null);
+        payload.setDistributionId(null);
+        messageResponse.setId(null);
+        messageResponse.setDistributionId(null);
+        assertThat(payload, equalTo(messageResponse));
+    }
+
+    private void failureCheck(CommunicationMessage message) {
+        messagingHandler.receiveMessage(message);
+        MessageResponse messageResponse = new MessageResponse(FAILED, message);
+        messageResponse.setErrorCode(TTL_EXCEED_MESSAGE_CODE);
+        messageResponse.setErrorMessage(MessagingHandler.ERROR_BUSINESS_RULE_VALIDATION);
+        ArgumentCaptor<MessageResponse> argumentCaptor = ArgumentCaptor.forClass(MessageResponse.class);
+        verify(kafkaTemplate).send(eq(FAIL_SEND), argumentCaptor.capture());
+        verify(kafkaTemplate, never()).send(eq(SUCCESS_SENT), argumentCaptor.capture());
+        MessageResponse payload = argumentCaptor.getValue();
+        payload.setId(null);
+        payload.setDistributionId(null);
+        messageResponse.setId(null);
+        messageResponse.setDistributionId(null);
+        assertThat(payload, equalTo(messageResponse));
+    }
+}

--- a/src/test/resources/ttl30minConfig.yml
+++ b/src/test/resources/ttl30minConfig.yml
@@ -2,3 +2,4 @@
 ttlRule:
   value: 30
   chronoUnit: MINUTES
+  action: REJECT

--- a/src/test/resources/ttl30minConfig.yml
+++ b/src/test/resources/ttl30minConfig.yml
@@ -1,0 +1,4 @@
+---
+ttlRule:
+  value: 30
+  chronoUnit: MINUTES

--- a/src/test/resources/ttlDefaultActionConfig.yml
+++ b/src/test/resources/ttlDefaultActionConfig.yml
@@ -2,5 +2,3 @@
 ttlRule:
   value: 1
   chronoUnit: MILLIS
-  action: REJECT
-

--- a/src/test/resources/ttlInaciveConfig.yml
+++ b/src/test/resources/ttlInaciveConfig.yml
@@ -1,0 +1,3 @@
+---
+ttlRule:
+  value: -1

--- a/src/test/resources/ttlInaciveConfig.yml
+++ b/src/test/resources/ttlInaciveConfig.yml
@@ -1,3 +1,5 @@
 ---
 ttlRule:
-  value: -1
+  value: 1
+  chronoUnit: MILLIS
+  action: NONE

--- a/src/test/resources/ttlNoConfig.yml
+++ b/src/test/resources/ttlNoConfig.yml
@@ -1,2 +1,2 @@
 ---
-businessTime:
+objectMapperFailsOnEmptyFile:

--- a/src/test/resources/ttlNoConfig.yml
+++ b/src/test/resources/ttlNoConfig.yml
@@ -1,0 +1,2 @@
+---
+businessTime:

--- a/src/test/resources/ttlOneMillisecondConfig.yml
+++ b/src/test/resources/ttlOneMillisecondConfig.yml
@@ -1,0 +1,4 @@
+---
+ttlRule:
+  value: 1
+  chronoUnit: MILLIS

--- a/src/test/resources/ttlWarningConfig.yml
+++ b/src/test/resources/ttlWarningConfig.yml
@@ -1,0 +1,5 @@
+---
+ttlRule:
+  value: 1
+  chronoUnit: MILLIS
+  action: WARNING


### PR DESCRIPTION
Rejects or warning messages if them exceeded configured TTL parameter.
In case of TTL parameters are not configured, rule is ignored.
In case of configured "action" value is NONE, rule is ignored.
In case of configured "action" value is missing, rule is ignored.
In case of configured "action" value is REJECT, rule behavior is rejecting message.
In case of configured "action" value is WARNING, rule behavior is log warning.

All cases are covered by the tests.