### PR TITLE
do not add leading bom symbol to message payload

### DIFF
--- a/src/main/java/com/icthh/xm/tmf/ms/communication/service/SmppService.java
+++ b/src/main/java/com/icthh/xm/tmf/ms/communication/service/SmppService.java
@@ -1,6 +1,5 @@
 package com.icthh.xm.tmf.ms.communication.service;
 
-import static java.nio.charset.StandardCharsets.UTF_16;
 import static java.nio.charset.StandardCharsets.UTF_16BE;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.jsmpp.bean.Alphabet.ALPHA_DEFAULT;

--- a/src/main/java/com/icthh/xm/tmf/ms/communication/service/SmppService.java
+++ b/src/main/java/com/icthh/xm/tmf/ms/communication/service/SmppService.java
@@ -1,6 +1,7 @@
 package com.icthh.xm.tmf.ms.communication.service;
 
 import static java.nio.charset.StandardCharsets.UTF_16;
+import static java.nio.charset.StandardCharsets.UTF_16BE;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.jsmpp.bean.Alphabet.ALPHA_DEFAULT;
 import static org.jsmpp.bean.Alphabet.ALPHA_UCS2;
@@ -180,7 +181,7 @@ public class SmppService {
        if (isAlpha(message)) {
            return new OctetString(MESSAGE_PAYLOAD.code(), message);
        } else {
-           return new OctetString(MESSAGE_PAYLOAD.code(), message, UTF_16.name());
+           return new OctetString(MESSAGE_PAYLOAD.code(), message, UTF_16BE.name());
        }
     }
 


### PR DESCRIPTION
do not add extra BOM (FEFF) symbol at the beginning of the message payload since
big endian is the default byte order mark for UCS2 and at the same time this symbol can lead to increased sms parts count

https://tools.ietf.org/html/rfc2781
4.3 Interpreting text labelled as UTF-16
"If the first two octets of the text is not 0xFE followed by
0xFF, and is not 0xFF followed by 0xFE, then the text SHOULD be
interpreted as being big-endian"