### PR TITLE
Feature - add TTL for firebase messages

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 rootProject.name=communication
-version=2.0.13
+version=2.0.14
 
 profile=dev
 

--- a/src/main/java/com/icthh/xm/tmf/ms/communication/messaging/handler/MobileAppMessageHandler.java
+++ b/src/main/java/com/icthh/xm/tmf/ms/communication/messaging/handler/MobileAppMessageHandler.java
@@ -5,7 +5,7 @@ import com.icthh.xm.commons.lep.spring.LepService;
 import com.icthh.xm.tmf.ms.communication.channel.mobileapp.FirebaseApplicationConfigurationProvider;
 import com.icthh.xm.tmf.ms.communication.lep.keresolver.CustomMessageCreateResolver;
 import com.icthh.xm.tmf.ms.communication.lep.keresolver.CustomMessageResolver;
-import com.icthh.xm.tmf.ms.communication.service.FirebaseService;
+import com.icthh.xm.tmf.ms.communication.service.firebase.FirebaseService;
 import com.icthh.xm.tmf.ms.communication.web.api.model.CommunicationMessage;
 import com.icthh.xm.tmf.ms.communication.web.api.model.CommunicationMessageCreate;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/icthh/xm/tmf/ms/communication/messaging/handler/MobileAppMessageHandler.java
+++ b/src/main/java/com/icthh/xm/tmf/ms/communication/messaging/handler/MobileAppMessageHandler.java
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-@LepService
+@LepService(group = "service.message")
 @Slf4j
 @ConditionalOnBean(FirebaseApplicationConfigurationProvider.class)
 public class MobileAppMessageHandler implements BasicMessageHandler {

--- a/src/main/java/com/icthh/xm/tmf/ms/communication/messaging/handler/ParameterNames.java
+++ b/src/main/java/com/icthh/xm/tmf/ms/communication/messaging/handler/ParameterNames.java
@@ -1,0 +1,45 @@
+package com.icthh.xm.tmf.ms.communication.messaging.handler;
+
+public final class ParameterNames {
+
+    /**
+     * Delivery report. Delivery report configuration (byte).
+     */
+    public static final String DELIVERY_REPORT = "DELIVERY.REPORT";
+
+    /**
+     * Optional parameters prefix, e.g. <i>OPTIONAL.6005</i></li>
+     */
+    public static final String OPTIONAL_PARAMETER_PREFIX = "OPTIONAL.";
+
+    /**
+     * Validity period. A number of seconds a message is valid.
+     */
+    public static final String VALIDITY_PERIOD = "VALIDITY.PERIOD";
+
+    /**
+     * Protocol id. SMPP protocol id value.
+     */
+    public static final String PROTOCOL_ID = "PROTOCOL.ID";
+
+    /**
+     * Notification badge. A number that is displayed over the app's icon.
+     */
+    public static final String BADGE = "BADGE";
+
+    /**
+     * URL of the image that is going to be displayed in the notification.
+     */
+    public static final String IMAGE = "IMAGE";
+
+    /**
+     * A unique identifier of the message.
+     */
+    public static final String MESSAGE_ID = "MESSAGE.ID";
+
+    /**
+     * Error code in case of an error.
+     */
+    public static final String ERROR_CODE = "ERROR.CODE";
+
+}

--- a/src/main/java/com/icthh/xm/tmf/ms/communication/messaging/handler/ParameterNames.java
+++ b/src/main/java/com/icthh/xm/tmf/ms/communication/messaging/handler/ParameterNames.java
@@ -42,4 +42,27 @@ public final class ParameterNames {
      */
     public static final String ERROR_CODE = "ERROR.CODE";
 
+    /**
+     * Response result type, see {@link ResultType}
+     */
+    public static final String RESULT_TYPE = "RESULT.TYPE";
+
+    public enum ResultType {
+
+        /**
+         * Includes success and error counts only.
+         */
+        SUMMARY,
+
+        /**
+         * Includes success and error counts, detailed description of error cases.
+         */
+        ERROR,
+
+        /**
+         * Includes success and error counts, detailed description
+         * of success and errors cases.
+         */
+        FULL
+    }
 }

--- a/src/main/java/com/icthh/xm/tmf/ms/communication/messaging/handler/SmppMessagingHandler.java
+++ b/src/main/java/com/icthh/xm/tmf/ms/communication/messaging/handler/SmppMessagingHandler.java
@@ -2,7 +2,7 @@ package com.icthh.xm.tmf.ms.communication.messaging.handler;
 
 import static com.icthh.xm.tmf.ms.communication.domain.MessageResponse.failed;
 import static com.icthh.xm.tmf.ms.communication.domain.MessageResponse.success;
-import static com.icthh.xm.tmf.ms.communication.messaging.handler.SmppMessagingHandler.ParameterNames.OPTIONAL_PARAMETER_PREFIX;
+import static com.icthh.xm.tmf.ms.communication.messaging.handler.ParameterNames.OPTIONAL_PARAMETER_PREFIX;
 import static java.util.stream.Collectors.toList;
 
 import com.google.common.primitives.Ints;
@@ -192,12 +192,4 @@ public class SmppMessagingHandler implements BasicMessageHandler {
         public static final String ERROR_SYSTEM_GENERAL_INTERNAL_SERVER_ERROR = "error.system.general.internalServerError";
     }
 
-    public static final class ParameterNames {
-        public static final String DELIVERY_REPORT = "DELIVERY.REPORT";
-        public static final String OPTIONAL_PARAMETER_PREFIX = "OPTIONAL.";
-        public static final String MESSAGE_ID = "MESSAGE.ID";
-        public static final String ERROR_CODE = "ERROR.CODE";
-        public static final String VALIDITY_PERIOD = "VALIDITY.PERIOD";
-        public static final String PROTOCOL_ID = "PROTOCOL.ID";
-    }
 }

--- a/src/main/java/com/icthh/xm/tmf/ms/communication/service/firebase/BadgeConfigurator.java
+++ b/src/main/java/com/icthh/xm/tmf/ms/communication/service/firebase/BadgeConfigurator.java
@@ -1,0 +1,35 @@
+package com.icthh.xm.tmf.ms.communication.service.firebase;
+
+import com.icthh.xm.tmf.ms.communication.messaging.handler.ParameterNames;
+import com.icthh.xm.tmf.ms.communication.utils.Utils;
+import com.icthh.xm.tmf.ms.communication.web.api.model.CommunicationMessage;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * Adds {@link com.icthh.xm.tmf.ms.communication.messaging.handler.ParameterNames#BADGE}
+ * configuration.
+ */
+@Component
+@Slf4j
+class BadgeConfigurator implements MessageConfigurator {
+    @Override
+    public void apply(BuilderWrapper builder, CommunicationMessage message,
+                      Map<String, String> characteristics) {
+        String badge = characteristics.get(ParameterNames.BADGE);
+        if (badge == null) {
+            return;
+        }
+
+        int badgeIntValue = Utils.parseIntOrException(badge);
+
+        log.debug("{} parameter is provided, adding to the request {}",
+            ParameterNames.BADGE, badgeIntValue);
+
+        builder.getApsBuilder().setBadge(badgeIntValue);
+        builder.getAndroidNotificationBuilder().setNotificationCount(badgeIntValue);
+        builder.getWebpushNotificationBuilder()
+            .setBadge(badge);
+    }
+}

--- a/src/main/java/com/icthh/xm/tmf/ms/communication/service/firebase/BuilderWrapper.java
+++ b/src/main/java/com/icthh/xm/tmf/ms/communication/service/firebase/BuilderWrapper.java
@@ -1,0 +1,27 @@
+package com.icthh.xm.tmf.ms.communication.service.firebase;
+
+import com.google.firebase.messaging.AndroidConfig;
+import com.google.firebase.messaging.AndroidNotification;
+import com.google.firebase.messaging.ApnsConfig;
+import com.google.firebase.messaging.Aps;
+import com.google.firebase.messaging.MulticastMessage;
+import com.google.firebase.messaging.Notification;
+import com.google.firebase.messaging.WebpushConfig;
+import com.google.firebase.messaging.WebpushNotification;
+import lombok.Data;
+
+/**
+ * Wrapper around Firebase {@link MulticastMessage} builders.
+ */
+@Data
+class BuilderWrapper {
+    private MulticastMessage.Builder firebaseMessageBuilder = MulticastMessage.builder();
+    private ApnsConfig.Builder apnsBuilder = ApnsConfig.builder();
+    private Aps.Builder apsBuilder = Aps.builder();
+    private AndroidConfig.Builder androidConfigBuilder = AndroidConfig.builder();
+    private WebpushConfig.Builder webPushBuilder = WebpushConfig.builder();
+    private Notification.Builder notificationBuilder = Notification.builder();
+    private AndroidNotification.Builder androidNotificationBuilder = AndroidNotification.builder();
+    private WebpushNotification.Builder webpushNotificationBuilder = WebpushNotification.builder();
+
+}

--- a/src/main/java/com/icthh/xm/tmf/ms/communication/service/firebase/BuilderWrapper.java
+++ b/src/main/java/com/icthh/xm/tmf/ms/communication/service/firebase/BuilderWrapper.java
@@ -8,20 +8,19 @@ import com.google.firebase.messaging.MulticastMessage;
 import com.google.firebase.messaging.Notification;
 import com.google.firebase.messaging.WebpushConfig;
 import com.google.firebase.messaging.WebpushNotification;
-import lombok.Data;
+import lombok.Value;
 
 /**
  * Wrapper around Firebase {@link MulticastMessage} builders.
  */
-@Data
+@Value
 class BuilderWrapper {
-    private MulticastMessage.Builder firebaseMessageBuilder = MulticastMessage.builder();
-    private ApnsConfig.Builder apnsBuilder = ApnsConfig.builder();
-    private Aps.Builder apsBuilder = Aps.builder();
-    private AndroidConfig.Builder androidConfigBuilder = AndroidConfig.builder();
-    private WebpushConfig.Builder webPushBuilder = WebpushConfig.builder();
-    private Notification.Builder notificationBuilder = Notification.builder();
-    private AndroidNotification.Builder androidNotificationBuilder = AndroidNotification.builder();
-    private WebpushNotification.Builder webpushNotificationBuilder = WebpushNotification.builder();
-
+    MulticastMessage.Builder firebaseMessageBuilder = MulticastMessage.builder();
+    ApnsConfig.Builder apnsBuilder = ApnsConfig.builder();
+    Aps.Builder apsBuilder = Aps.builder();
+    AndroidConfig.Builder androidConfigBuilder = AndroidConfig.builder();
+    WebpushConfig.Builder webPushBuilder = WebpushConfig.builder();
+    Notification.Builder notificationBuilder = Notification.builder();
+    AndroidNotification.Builder androidNotificationBuilder = AndroidNotification.builder();
+    WebpushNotification.Builder webpushNotificationBuilder = WebpushNotification.builder();
 }

--- a/src/main/java/com/icthh/xm/tmf/ms/communication/service/firebase/ExtendedCommunicationMessageFactory.java
+++ b/src/main/java/com/icthh/xm/tmf/ms/communication/service/firebase/ExtendedCommunicationMessageFactory.java
@@ -1,0 +1,21 @@
+package com.icthh.xm.tmf.ms.communication.service.firebase;
+
+import com.icthh.xm.tmf.ms.communication.web.api.model.CommunicationMessage;
+import com.icthh.xm.tmf.ms.communication.web.api.model.ExtendedCommunicationMessage;
+import org.springframework.beans.BeanUtils;
+
+public class ExtendedCommunicationMessageFactory {
+    public static ExtendedCommunicationMessage newMessage() {
+        ExtendedCommunicationMessage message = new ExtendedCommunicationMessage();
+        message.atType("ExtendedCommunicationMessage");
+        message.atBaseType("CommunicationMessage");
+        message.atSchemaLocation("https://github.com/xm-online/tmf-ms-communication/blob/master/src/main/resources/swagger/api-extention.yml");
+        return message;
+    }
+
+    public static ExtendedCommunicationMessage newMessage(CommunicationMessage source) {
+        ExtendedCommunicationMessage message = newMessage();
+        BeanUtils.copyProperties(source, message);
+        return message;
+    }
+}

--- a/src/main/java/com/icthh/xm/tmf/ms/communication/service/firebase/ExtendedCommunicationMessageFactory.java
+++ b/src/main/java/com/icthh/xm/tmf/ms/communication/service/firebase/ExtendedCommunicationMessageFactory.java
@@ -9,7 +9,7 @@ public class ExtendedCommunicationMessageFactory {
         ExtendedCommunicationMessage message = new ExtendedCommunicationMessage();
         message.atType("ExtendedCommunicationMessage");
         message.atBaseType("CommunicationMessage");
-        message.atSchemaLocation("https://github.com/xm-online/tmf-ms-communication/blob/master/src/main/resources/swagger/api-extention.yml");
+        message.atSchemaLocation("https://github.com/xm-online/tmf-ms-communication/blob/master/src/main/resources/swagger/api-extension.yml");
         return message;
     }
 

--- a/src/main/java/com/icthh/xm/tmf/ms/communication/service/firebase/FirebaseService.java
+++ b/src/main/java/com/icthh/xm/tmf/ms/communication/service/firebase/FirebaseService.java
@@ -41,6 +41,11 @@ import org.springframework.util.CollectionUtils;
 @ConditionalOnBean(FirebaseApplicationConfigurationProvider.class)
 public class FirebaseService {
 
+    /**
+     * The maximum number of receivers allowed for a batch operation.
+     */
+    public static final int RECEIVERS_MAX_SIZE = 500;
+
     private final FirebaseApplicationConfigurationProvider firebaseApplicationConfigurationProvider;
     private final TenantContextHolder tenantContextHolder;
     private final MobileAppMessagePayloadCustomizationService payloadCustomizer;
@@ -118,7 +123,7 @@ public class FirebaseService {
 
         if (receivers.isEmpty()) {
             throw new BusinessException(ErrorCodes.RECEIVER_INVALID, "Receiver list - no appUserId specified");
-        } else if (receivers.size() > 500) {
+        } else if (receivers.size() > RECEIVERS_MAX_SIZE) {
             throw new BusinessException(ErrorCodes.RECEIVER_COUNT, "The number of receivers exceeds 500 allowed");
         }
         return receivers;

--- a/src/main/java/com/icthh/xm/tmf/ms/communication/service/firebase/ImageConfigurator.java
+++ b/src/main/java/com/icthh/xm/tmf/ms/communication/service/firebase/ImageConfigurator.java
@@ -1,0 +1,18 @@
+package com.icthh.xm.tmf.ms.communication.service.firebase;
+
+import com.icthh.xm.tmf.ms.communication.messaging.handler.ParameterNames;
+import com.icthh.xm.tmf.ms.communication.web.api.model.CommunicationMessage;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+/**
+ * Adds {@link com.icthh.xm.tmf.ms.communication.messaging.handler.ParameterNames#IMAGE}
+ * configuration.
+ */
+@Component
+class ImageConfigurator implements MessageConfigurator {
+    @Override
+    public void apply(BuilderWrapper builder, CommunicationMessage message, Map<String, String> characteristics) {
+        builder.getNotificationBuilder().setImage(characteristics.get(ParameterNames.IMAGE));
+    }
+}

--- a/src/main/java/com/icthh/xm/tmf/ms/communication/service/firebase/MessageConfigurator.java
+++ b/src/main/java/com/icthh/xm/tmf/ms/communication/service/firebase/MessageConfigurator.java
@@ -1,0 +1,21 @@
+package com.icthh.xm.tmf.ms.communication.service.firebase;
+
+import com.icthh.xm.tmf.ms.communication.web.api.model.CommunicationMessage;
+import java.util.Map;
+
+/**
+ * Describes a component that is able to configure Firebase message, e.g. apply
+ * parameters based on the request.
+ */
+interface MessageConfigurator {
+
+    /**
+     * Applies a configuration
+     *
+     * @param builder         message builder wrapper
+     * @param message         message request
+     * @param characteristics request characteristics
+     */
+    void apply(BuilderWrapper builder, CommunicationMessage message,
+               Map<String, String> characteristics);
+}

--- a/src/main/java/com/icthh/xm/tmf/ms/communication/service/firebase/ValidityPeriodConfigurator.java
+++ b/src/main/java/com/icthh/xm/tmf/ms/communication/service/firebase/ValidityPeriodConfigurator.java
@@ -1,0 +1,38 @@
+package com.icthh.xm.tmf.ms.communication.service.firebase;
+
+import static com.icthh.xm.tmf.ms.communication.messaging.handler.ParameterNames.VALIDITY_PERIOD;
+import static com.icthh.xm.tmf.ms.communication.utils.Utils.parseIntOrException;
+
+import com.icthh.xm.tmf.ms.communication.web.api.model.CommunicationMessage;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Component;
+
+/**
+ * Adds {@link com.icthh.xm.tmf.ms.communication.messaging.handler.ParameterNames#VALIDITY_PERIOD}
+ * configuration.
+ */
+@Component
+@Slf4j
+class ValidityPeriodConfigurator implements MessageConfigurator {
+    @Override
+    public void apply(BuilderWrapper builder, CommunicationMessage message, Map<String, String> characteristics) {
+        String ttl = characteristics.get(VALIDITY_PERIOD);
+        if (StringUtils.isBlank(ttl)) {
+            return;
+        }
+
+        int ttlSeconds = parseIntOrException(ttl);
+
+        log.debug("{} parameter is provided, adding to the request {}",
+            VALIDITY_PERIOD, ttlSeconds);
+
+        builder.getApnsBuilder().putHeader("apns-expiration",
+            String.valueOf(Instant.now().plus(ttlSeconds, ChronoUnit.SECONDS).toEpochMilli() / 1000));
+
+        builder.getAndroidConfigBuilder().setTtl(ttlSeconds * 1000L);
+    }
+}

--- a/src/main/java/com/icthh/xm/tmf/ms/communication/service/firebase/response/ErrorOnlyResponseBuildingStrategy.java
+++ b/src/main/java/com/icthh/xm/tmf/ms/communication/service/firebase/response/ErrorOnlyResponseBuildingStrategy.java
@@ -1,0 +1,56 @@
+package com.icthh.xm.tmf.ms.communication.service.firebase.response;
+
+import com.google.firebase.messaging.BatchResponse;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.SendResponse;
+import com.icthh.xm.tmf.ms.communication.messaging.handler.ParameterNames;
+import com.icthh.xm.tmf.ms.communication.web.api.model.CommunicationMessage;
+import com.icthh.xm.tmf.ms.communication.web.api.model.Detail;
+import com.icthh.xm.tmf.ms.communication.web.api.model.ErrorDetail;
+import com.icthh.xm.tmf.ms.communication.web.api.model.ExtendedCommunicationMessage;
+import com.icthh.xm.tmf.ms.communication.web.api.model.Receiver;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.stereotype.Component;
+
+/**
+ * Includes success and error counts, detailed description of error cases.
+ */
+@Component
+public class ErrorOnlyResponseBuildingStrategy extends SummaryResponseBuildingStrategy {
+
+    @Override
+    public String getName() {
+        return ParameterNames.ResultType.ERROR.name();
+    }
+
+    @Override
+    public ExtendedCommunicationMessage buildCommunicationResponse(BatchResponse batchResponse,
+                                                                   CommunicationMessage msg, List<Receiver> receivers) {
+
+        ExtendedCommunicationMessage message = super.buildCommunicationResponse(batchResponse, msg, receivers);
+
+        List<Detail> details = new ArrayList<>();
+        List<SendResponse> responses = batchResponse.getResponses();
+        for (int i = 0; i < responses.size(); i++) {
+            SendResponse response = responses.get(i);
+
+            if (!response.isSuccessful()) {
+                FirebaseMessagingException exception = response.getException();
+
+                details.add(new Detail()
+                    .receiver(receivers.get(i))
+                    .status(Detail.Status.ERROR)
+                    .error(new ErrorDetail()
+                        .code(String.valueOf(exception.getMessagingErrorCode()))
+                        .description(exception.getMessage())));
+            }
+        }
+
+        message.result().details(details);
+        message.id(UUID.randomUUID().toString());
+
+        return message;
+    }
+}

--- a/src/main/java/com/icthh/xm/tmf/ms/communication/service/firebase/response/FullResponseBuildingStrategy.java
+++ b/src/main/java/com/icthh/xm/tmf/ms/communication/service/firebase/response/FullResponseBuildingStrategy.java
@@ -1,0 +1,60 @@
+package com.icthh.xm.tmf.ms.communication.service.firebase.response;
+
+import com.google.firebase.messaging.BatchResponse;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.SendResponse;
+import com.icthh.xm.tmf.ms.communication.messaging.handler.ParameterNames;
+import com.icthh.xm.tmf.ms.communication.web.api.model.CommunicationMessage;
+import com.icthh.xm.tmf.ms.communication.web.api.model.Detail;
+import com.icthh.xm.tmf.ms.communication.web.api.model.ErrorDetail;
+import com.icthh.xm.tmf.ms.communication.web.api.model.ExtendedCommunicationMessage;
+import com.icthh.xm.tmf.ms.communication.web.api.model.Receiver;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.stereotype.Component;
+
+/**
+ * Includes success and error counts, detailed description
+ * of success and errors cases.
+ */
+@Component
+public class FullResponseBuildingStrategy extends SummaryResponseBuildingStrategy {
+
+    @Override
+    public String getName() {
+        return ParameterNames.ResultType.FULL.name();
+    }
+
+    @Override
+    public ExtendedCommunicationMessage buildCommunicationResponse(BatchResponse batchResponse, CommunicationMessage msg, List<Receiver> receivers) {
+        ExtendedCommunicationMessage message = super.buildCommunicationResponse(batchResponse, msg, receivers);
+
+        List<Detail> details = new ArrayList<>();
+        List<SendResponse> responses = batchResponse.getResponses();
+        for (int i = 0; i < responses.size(); i++) {
+            SendResponse response = responses.get(i);
+
+            Detail detail = new Detail()
+                .receiver(receivers.get(i));
+
+            if (response.isSuccessful()) {
+                detail.status(Detail.Status.SUCCESS)
+                    .messageId(response.getMessageId());
+            } else {
+                FirebaseMessagingException exception = response.getException();
+
+                detail.status(Detail.Status.ERROR)
+                    .error(new ErrorDetail()
+                        .code(String.valueOf(exception.getMessagingErrorCode()))
+                        .description(exception.getMessage()));
+            }
+            details.add(detail);
+        }
+
+        message.result().details(details);
+        message.id(UUID.randomUUID().toString());
+
+        return message;
+    }
+}

--- a/src/main/java/com/icthh/xm/tmf/ms/communication/service/firebase/response/ResponseBuildingStrategy.java
+++ b/src/main/java/com/icthh/xm/tmf/ms/communication/service/firebase/response/ResponseBuildingStrategy.java
@@ -1,0 +1,24 @@
+package com.icthh.xm.tmf.ms.communication.service.firebase.response;
+
+import com.google.firebase.messaging.BatchResponse;
+import com.icthh.xm.tmf.ms.communication.web.api.model.CommunicationMessage;
+import com.icthh.xm.tmf.ms.communication.web.api.model.ExtendedCommunicationMessage;
+import com.icthh.xm.tmf.ms.communication.web.api.model.Receiver;
+import java.util.List;
+
+/**
+ * Describes a strategy of building a message response.
+ */
+public interface ResponseBuildingStrategy {
+
+    /**
+     * Builds a message response
+     */
+    ExtendedCommunicationMessage buildCommunicationResponse(BatchResponse batchResponse,
+                                                            CommunicationMessage msg, List<Receiver> receivers);
+
+    /**
+     * @return strategy name
+     */
+    String getName();
+}

--- a/src/main/java/com/icthh/xm/tmf/ms/communication/service/firebase/response/SummaryResponseBuildingStrategy.java
+++ b/src/main/java/com/icthh/xm/tmf/ms/communication/service/firebase/response/SummaryResponseBuildingStrategy.java
@@ -1,0 +1,37 @@
+package com.icthh.xm.tmf.ms.communication.service.firebase.response;
+
+import com.google.firebase.messaging.BatchResponse;
+import com.icthh.xm.tmf.ms.communication.messaging.handler.ParameterNames;
+import com.icthh.xm.tmf.ms.communication.service.firebase.ExtendedCommunicationMessageFactory;
+import com.icthh.xm.tmf.ms.communication.web.api.model.CommunicationMessage;
+import com.icthh.xm.tmf.ms.communication.web.api.model.ExtendedCommunicationMessage;
+import com.icthh.xm.tmf.ms.communication.web.api.model.Receiver;
+import com.icthh.xm.tmf.ms.communication.web.api.model.Result;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.stereotype.Component;
+
+/**
+ * Includes success and error counts only.
+ */
+@Component
+public class SummaryResponseBuildingStrategy implements ResponseBuildingStrategy {
+
+    @Override
+    public String getName() {
+        return ParameterNames.ResultType.SUMMARY.name();
+    }
+
+    @Override
+    public ExtendedCommunicationMessage buildCommunicationResponse(BatchResponse batchResponse,
+                                                                   CommunicationMessage msg, List<Receiver> receivers) {
+        ExtendedCommunicationMessage message = ExtendedCommunicationMessageFactory.newMessage(msg);
+        message.id(UUID.randomUUID().toString());
+        message.result(new Result()
+            .successCount(batchResponse.getSuccessCount())
+            .failureCount(batchResponse.getFailureCount()));
+        return message;
+    }
+
+
+}

--- a/src/main/java/com/icthh/xm/tmf/ms/communication/utils/Utils.java
+++ b/src/main/java/com/icthh/xm/tmf/ms/communication/utils/Utils.java
@@ -1,0 +1,16 @@
+package com.icthh.xm.tmf.ms.communication.utils;
+
+import com.icthh.xm.commons.exceptions.BusinessException;
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class Utils {
+
+    public static int parseIntOrException(String value) {
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            throw new BusinessException("error.parameter.invalid", "Invalid parameter value " + value);
+        }
+    }
+}

--- a/src/main/java/com/icthh/xm/tmf/ms/communication/web/api/model/Detail.java
+++ b/src/main/java/com/icthh/xm/tmf/ms/communication/web/api/model/Detail.java
@@ -1,0 +1,18 @@
+package com.icthh.xm.tmf.ms.communication.web.api.model;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+@Data
+@Accessors(fluent = true)
+public class Detail {
+    private Status status;
+    private Receiver receiver;
+    private String messageId;
+    private ErrorDetail error;
+
+    public enum Status {
+        SUCCESS,
+        ERROR
+    }
+}

--- a/src/main/java/com/icthh/xm/tmf/ms/communication/web/api/model/Detail.java
+++ b/src/main/java/com/icthh/xm/tmf/ms/communication/web/api/model/Detail.java
@@ -1,14 +1,19 @@
 package com.icthh.xm.tmf.ms.communication.web.api.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 import lombok.experimental.Accessors;
 
 @Data
 @Accessors(fluent = true)
 public class Detail {
+    @JsonProperty("status")
     private Status status;
+    @JsonProperty("receiver")
     private Receiver receiver;
+    @JsonProperty("messageId")
     private String messageId;
+    @JsonProperty("error")
     private ErrorDetail error;
 
     public enum Status {

--- a/src/main/java/com/icthh/xm/tmf/ms/communication/web/api/model/ErrorDetail.java
+++ b/src/main/java/com/icthh/xm/tmf/ms/communication/web/api/model/ErrorDetail.java
@@ -1,0 +1,11 @@
+package com.icthh.xm.tmf.ms.communication.web.api.model;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+@Data
+@Accessors(fluent = true)
+public class ErrorDetail {
+    private String code;
+    private String description;
+}

--- a/src/main/java/com/icthh/xm/tmf/ms/communication/web/api/model/ErrorDetail.java
+++ b/src/main/java/com/icthh/xm/tmf/ms/communication/web/api/model/ErrorDetail.java
@@ -1,11 +1,14 @@
 package com.icthh.xm.tmf.ms.communication.web.api.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 import lombok.experimental.Accessors;
 
 @Data
 @Accessors(fluent = true)
 public class ErrorDetail {
+    @JsonProperty("code")
     private String code;
+    @JsonProperty("description")
     private String description;
 }

--- a/src/main/java/com/icthh/xm/tmf/ms/communication/web/api/model/ExtendedCommunicationMessage.java
+++ b/src/main/java/com/icthh/xm/tmf/ms/communication/web/api/model/ExtendedCommunicationMessage.java
@@ -1,5 +1,6 @@
 package com.icthh.xm.tmf.ms.communication.web.api.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.experimental.Accessors;
@@ -8,5 +9,6 @@ import lombok.experimental.Accessors;
 @EqualsAndHashCode(callSuper = true)
 @Accessors(fluent = true)
 public class ExtendedCommunicationMessage extends CommunicationMessage {
+    @JsonProperty("result")
     private Result result;
 }

--- a/src/main/java/com/icthh/xm/tmf/ms/communication/web/api/model/ExtendedCommunicationMessage.java
+++ b/src/main/java/com/icthh/xm/tmf/ms/communication/web/api/model/ExtendedCommunicationMessage.java
@@ -1,0 +1,12 @@
+package com.icthh.xm.tmf.ms.communication.web.api.model;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.experimental.Accessors;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@Accessors(fluent = true)
+public class ExtendedCommunicationMessage extends CommunicationMessage {
+    private Result result;
+}

--- a/src/main/java/com/icthh/xm/tmf/ms/communication/web/api/model/Result.java
+++ b/src/main/java/com/icthh/xm/tmf/ms/communication/web/api/model/Result.java
@@ -1,5 +1,6 @@
 package com.icthh.xm.tmf.ms.communication.web.api.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 import lombok.Data;
 import lombok.experimental.Accessors;
@@ -7,7 +8,10 @@ import lombok.experimental.Accessors;
 @Data
 @Accessors(fluent = true)
 public class Result {
+    @JsonProperty("successCount")
     private Integer successCount;
+    @JsonProperty("failureCount")
     private Integer failureCount;
+    @JsonProperty("details")
     private List<Detail> details;
 }

--- a/src/main/java/com/icthh/xm/tmf/ms/communication/web/api/model/Result.java
+++ b/src/main/java/com/icthh/xm/tmf/ms/communication/web/api/model/Result.java
@@ -1,0 +1,13 @@
+package com.icthh.xm.tmf.ms.communication.web.api.model;
+
+import java.util.List;
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+@Data
+@Accessors(fluent = true)
+public class Result {
+    private Integer successCount;
+    private Integer failureCount;
+    private List<Detail> details;
+}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -4,14 +4,14 @@
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <charset>utf-8</charset>
-            <Pattern>%d %-5level [%thread] [%X{rid}] %logger{0}: %msg%n</Pattern>
+            <Pattern>${LOG_STDOUT_PATTERN:-%d %-5level [%thread] [%X{rid}] %logger{0}: %msg%n}</Pattern>
         </encoder>
     </appender>
 
     <appender name="STDOUT_JSON" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
-    </appender> 
-    
+    </appender>
+
     <logger name="com.icthh.xm" level="#logback.loglevel#"/>
     <logger name="io.github.jhipster" level="#logback.loglevel#"/>
 

--- a/src/main/resources/swagger/api-extension.yml
+++ b/src/main/resources/swagger/api-extension.yml
@@ -10,15 +10,6 @@ definitions:
                 result:
                     $ref: '#/definitions/Result'
                     description: Arequest results
-                '@type':
-                    type: string
-                    description: (optional) The class type of a REST resource.
-                '@schemaLocation':
-                    type: string
-                    description: (optional) A link to the schema describing a REST resource.
-                '@baseType':
-                    type: string
-                    description: The class type of the actual resource (for type extension).
     Result:
         required:
             - successCount

--- a/src/main/resources/swagger/api-extention.yml
+++ b/src/main/resources/swagger/api-extention.yml
@@ -1,0 +1,53 @@
+swagger: '2.0'
+definitions:
+    ExtendedCommunicationMessage:
+        allOf:
+            -   $ref: '#/definitions/CommunicationMessage'
+            -   type: object
+            required:
+                - result
+            properties:
+                result:
+                    $ref: '#/definitions/Result'
+                    description: Arequest results
+                '@type':
+                    type: string
+                    description: (optional) The class type of a REST resource.
+                '@schemaLocation':
+                    type: string
+                    description: (optional) A link to the schema describing a REST resource.
+                '@baseType':
+                    type: string
+                    description: The class type of the actual resource (for type extension).
+    Result:
+        required:
+            - successCount
+            - failureCount
+        properties:
+            successCount:
+                type: integer
+            failureCount:
+                type: integer
+            details:
+                $ref: '#/definitions/Details'
+    Details:
+        required:
+            - status
+            - receiver
+        properties:
+            status:
+                type: string
+            receiver:
+                $ref: '#/definitions/Receiver'
+            messageId:
+                type: string
+            error:
+                $ref: '#/definitions/ErrorDescription'
+    ErrorDescription:
+        required:
+            - code
+        properties:
+            code:
+                type: string
+            description:
+                type: string

--- a/src/test/java/com/icthh/xm/tmf/ms/communication/messaging/handler/MobileAppMessageHandlerTest.java
+++ b/src/test/java/com/icthh/xm/tmf/ms/communication/messaging/handler/MobileAppMessageHandlerTest.java
@@ -3,7 +3,7 @@ package com.icthh.xm.tmf.ms.communication.messaging.handler;
 import static com.icthh.xm.tmf.ms.communication.messaging.handler.SmppMessagingHandlerTest.message;
 import static org.mockito.Mockito.verify;
 
-import com.icthh.xm.tmf.ms.communication.service.FirebaseService;
+import com.icthh.xm.tmf.ms.communication.service.firebase.FirebaseService;
 import com.icthh.xm.tmf.ms.communication.web.api.model.CommunicationMessage;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/src/test/java/com/icthh/xm/tmf/ms/communication/messaging/handler/SmppMessagingHandlerTest.java
+++ b/src/test/java/com/icthh/xm/tmf/ms/communication/messaging/handler/SmppMessagingHandlerTest.java
@@ -4,9 +4,9 @@ import static com.icthh.xm.tmf.ms.communication.domain.DeliveryReport.deliveryRe
 import static com.icthh.xm.tmf.ms.communication.domain.MessageResponse.DISTRIBUTION_ID;
 import static com.icthh.xm.tmf.ms.communication.domain.MessageResponse.Status.FAILED;
 import static com.icthh.xm.tmf.ms.communication.domain.MessageResponse.Status.SUCCESS;
-import static com.icthh.xm.tmf.ms.communication.messaging.handler.SmppMessagingHandler.ParameterNames.DELIVERY_REPORT;
-import static com.icthh.xm.tmf.ms.communication.messaging.handler.SmppMessagingHandler.ParameterNames.ERROR_CODE;
-import static com.icthh.xm.tmf.ms.communication.messaging.handler.SmppMessagingHandler.ParameterNames.MESSAGE_ID;
+import static com.icthh.xm.tmf.ms.communication.messaging.handler.ParameterNames.DELIVERY_REPORT;
+import static com.icthh.xm.tmf.ms.communication.messaging.handler.ParameterNames.ERROR_CODE;
+import static com.icthh.xm.tmf.ms.communication.messaging.handler.ParameterNames.MESSAGE_ID;
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static java.nio.charset.StandardCharsets.UTF_16;
 import static java.nio.charset.StandardCharsets.UTF_8;

--- a/src/test/java/com/icthh/xm/tmf/ms/communication/rules/BusinessTimeConfigRuleTest.java
+++ b/src/test/java/com/icthh/xm/tmf/ms/communication/rules/BusinessTimeConfigRuleTest.java
@@ -2,8 +2,8 @@ package com.icthh.xm.tmf.ms.communication.rules;
 
 import static com.icthh.xm.tmf.ms.communication.domain.MessageResponse.Status.FAILED;
 import static com.icthh.xm.tmf.ms.communication.domain.MessageResponse.Status.SUCCESS;
+import static com.icthh.xm.tmf.ms.communication.messaging.handler.ParameterNames.ERROR_CODE;
 import static com.icthh.xm.tmf.ms.communication.messaging.handler.SmppMessagingHandler.ERROR_BUSINESS_RULE_VALIDATION;
-import static com.icthh.xm.tmf.ms.communication.messaging.handler.SmppMessagingHandler.ParameterNames.ERROR_CODE;
 import static com.icthh.xm.tmf.ms.communication.messaging.handler.SmppMessagingHandlerTest.FAIL_SEND;
 import static com.icthh.xm.tmf.ms.communication.messaging.handler.SmppMessagingHandlerTest.SUCCESS_SENT;
 import static com.icthh.xm.tmf.ms.communication.messaging.handler.SmppMessagingHandlerTest.createApplicationProperties;

--- a/src/test/java/com/icthh/xm/tmf/ms/communication/service/firebase/FirebaseServiceTest.java
+++ b/src/test/java/com/icthh/xm/tmf/ms/communication/service/firebase/FirebaseServiceTest.java
@@ -2,6 +2,7 @@ package com.icthh.xm.tmf.ms.communication.service.firebase;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
@@ -170,8 +171,8 @@ public class FirebaseServiceTest {
         Map<String, String> apnHeaders = (Map<String, String>) extractField("headers", apnsConfig);
         Object expiration = apnHeaders.get("apns-expiration");
         assertNotNull(expiration);
-        assertEquals(0, Duration.between(Instant.ofEpochMilli(Long.parseLong((String) expiration) * 1000),
-            beforeTest.plus(300, ChronoUnit.SECONDS)).toSeconds());
+        assertTrue(Math.abs(Duration.between(Instant.ofEpochMilli(Long.parseLong((String) expiration) * 1000),
+            beforeTest.plus(300, ChronoUnit.SECONDS)).toSeconds()) <= 1);
 
         //check badge
         assertEquals(Integer.valueOf(BADGE_VALUE),


### PR DESCRIPTION
1. Add VALIDITY.PERIOD (i.e. Time-To-Live) parameter to the request.
2. Extend the response with batch operation results.
3. Add LOG_STDOUT_PATTERN env variable lookup to override the pattern.
4. Do some refactoring.