### PR TITLE
Update xm-commons to 5.0.39

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 rootProject.name=communication
-version=2.0.71
+version=2.0.72
 
 profile=dev
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ jacksonDatabindNullableVersion=0.2.10
 lombok_version=1.18.42
 springdocOpenapiVersion=3.0.3
 
-xm_commons_version=5.0.36
+xm_commons_version=5.0.39
 
 jaxbRuntimeVersion=4.0.4
 


### PR DESCRIPTION
Bumps xm_commons_version from 5.0.36 to 5.0.39, the current release
per Maven Central metadata (published 2026-08-09).

Verified with `./gradlew clean test` on Eclipse Temurin 25 and
Gradle 9.2.1: BUILD SUCCESSFUL, 169 tests, no failures.